### PR TITLE
Fix code-signing issue with the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,16 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*.*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <createSourcesJar>true</createSourcesJar>
               <shadeSourcesContent>true</shadeSourcesContent>
               <shadedArtifactAttached>false</shadedArtifactAttached>


### PR DESCRIPTION
Prior to this change, when I run `mvn package` and try to execute the resulting jar, I get:

```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
```

This appears to possibly be due to a dependency pulling in its own codesign signature?  I didn't check which dependency.  A signature for a dependency will of course not match our whole build.

Proposed workaround is to strip out code-signing info from the jar.  We could also have the build sign it properly, but I would expect that to require devs to set up their own signing keys.